### PR TITLE
Fix Renovate Configuration Error

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,6 @@
     ":rebaseStalePrs",
     ":disableDependencyDashboard"
   ],
-  "platform": "github",
   "timezone": "Europe/Berlin",
   "packageRules": [
     {


### PR DESCRIPTION
Remove platform setting from renovate.json
```
WARN: Found renovate config warnings
{
  "warnings": [
    {
      "topic": "Configuration Error",
      "message": "The \"platform\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
    }
  ]
}
```